### PR TITLE
remove incorrect migration

### DIFF
--- a/db/migrate/20160411015745_drop_friendships.rb
+++ b/db/migrate/20160411015745_drop_friendships.rb
@@ -1,8 +1,0 @@
-class DropFriendships < ActiveRecord::Migration
-   #this migration is getting rid of an old friendships table that i made by 
-   #mistake. how can i get rid of it?
-
-   def change
-      drop_table :friendships
-   end
-end


### PR DESCRIPTION
trying to remove ‘friendships’, but the table does not exist
